### PR TITLE
packaging: install build targets and add docs build option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,3 +26,12 @@ coda_fwinfo_sources = [
 	'src/reorder.h'
 ]
 executable('coda-fwinfo', coda_fwinfo_sources, install : true)
+
+codabits_docs = [
+	'README.rst',
+	'doc/bit-isa.rst',
+	'doc/bit.rst'
+]
+if get_option('docs')
+	install_data(codabits_docs, install_dir: 'share/doc/coda-bits')
+endif

--- a/meson.build
+++ b/meson.build
@@ -11,18 +11,18 @@ bitdis_sources = [
 	'src/reorder.c',
 	'src/reorder.h'
 ]
-executable('bitdis', bitdis_sources)
+executable('bitdis', bitdis_sources, install : true)
 
 bitspl_sources = [
 	'src/bitspl.c',
 	'src/reorder.c',
 	'src/reorder.h'
 ]
-executable('bitspl', bitspl_sources)
+executable('bitspl', bitspl_sources, install : true)
 
 coda_fwinfo_sources = [
 	'src/coda-fwinfo.c',
 	'src/reorder.c',
 	'src/reorder.h'
 ]
-executable('coda-fwinfo', coda_fwinfo_sources)
+executable('coda-fwinfo', coda_fwinfo_sources, install : true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('docs',
+	type: 'boolean',
+	value: false,
+	description: 'Install documentation')


### PR DESCRIPTION
To help distro maintainers package coda-bits this sets the executable build target as installable and also adds a docs option to install documentation (false by default).

Tested on updated Arch Linux.